### PR TITLE
Fix typo in preface: 'Finiten' to ' Finite'

### DIFF
--- a/content/preface.tex
+++ b/content/preface.tex
@@ -27,7 +27,7 @@ In \emph{Kapitel 2} beschäftigen wir uns mit dem Gegenbegriff zum Problem:
 Dessen Lösung, auch \emph{Algorithmus} genannt.
 Wir differenzieren zwischen Algorithmus und Implementierung
 und lernen einen Formalismus zur Implementierung von Algorithmen kennen:
-Deterministisch Finiten Automaten (DFA).
+Deterministisch Finite Automaten (DFA).
 DFAs ``erkennen'' eine spezielle Klasse von formalen Sprachen,
 \emph{regulären Sprachen},
 das heißt alle Probleme, die mit regulären Sprachen repräsentiert werden können,

--- a/content/preface.tex
+++ b/content/preface.tex
@@ -48,8 +48,8 @@ gegenüber empirischen Messungen runden das Kapitel ab.
 
 Zu Beginn von \emph{Kapitel 4} identifizieren wir Probleme,
 die mit einem DFA nicht zu lösen sind
-und die Methode, wir wir diese Beschränkung beweisen können.
-Mit den \emph{Turing-Maschinen} lernen wir in einen Formalismus kennen,
+und die Methode, wie wir diese Beschränkung beweisen können.
+Mit den \emph{Turing-Maschinen} lernen wir einen Formalismus kennen,
 der diese Beschränkungen nicht teilt.
 Turing-Maschinen sind der zentrale Formalismus sowohl
 in der Komplexitätstheorie,
@@ -61,7 +61,7 @@ der ``mächtiger'' als Turingmaschinen ist.
 Mit den Turing-Maschinen haben wir das nötige Konzept an der Hand,
 um die Hauptfrage des Skriptes in den folgenden beiden Kapiteln zu beantworten.
 
-Zentrale Ergebnisse und einige offenen Fragen der Komplexitätstheorie
+Zentrale Ergebnisse und einige offene Fragen der Komplexitätstheorie
 werden in \emph{Kapitel 5} besprochen.
 Diese Zusammenfassung ist ein Teil der Antwort auf die Frage,
 warum IT-Fachkräfte mit einem starken Hintergrund in theoretischer Informatik
@@ -87,7 +87,7 @@ Diese Aspekte rechtfertigen eine gesonderte Behandlung,
 auch wenn sie außerhalb des Leitgedankens dieses Skriptes sind.
 
 \emph{Kapitel 8} bietet einen Überblick,
-wie Interessierte von den dem Inhalt dieses Skriptes tiefer in die theoretische Informatik
+wie Interessierte vom Inhalt dieses Skriptes tiefer in die theoretische Informatik
 eintauchen können.
 Es listet einige ``Absprungspunkte'' auf und zeigt,
 wo diese in gängigen Einführungen und weiterführender Literatur diskutiert werden:


### PR DESCRIPTION
Hi Tobias,

wollte den Impuls von Dir aufnehmen und einfach Mal einen Pull Request durchführen. 

Im Preface Zeile 30 müsste es mE "Deterministisch Finite Automaten (DFA)" statt "Deterministisch Finiten Automaten (DFA)" heißen.

Ich schätze es empfiehlt sich, nicht für jeden Typo einen eigenen Pull Request aufzumachen, aber ich wollte das jetzt einfach direkt Mal testen. Schätze das macht kapitelweise vermutlich mehr Sinn.

Grüße Tony