### PR TITLE
small changes in preface.tex / einleitung.tex / grundlagen.tex

### DIFF
--- a/content/aufwand.tex
+++ b/content/aufwand.tex
@@ -33,7 +33,7 @@ zeitlichem Aufwand beziehungsweise zeitlicher Effizienz sprechen.
 Allerdings kann vieles auf Raum-Effizienz übertragen werden,
 das wir in diesem Kapitel entwickeln.
 
-Wir wollen über diese drei folgenden Schritte zu einem Verständnis von Aufwand zu kommen:
+Wir wollen über diese drei folgenden Schritte zu einem Verständnis von Aufwand kommen:
 \begin{itemize}
     \item Aufwand für einen Lauf einer spezifischen Turingmaschine auf einem spezifischen Wort.
     \item Abschätzung für die Länge von Läufen einer spezifischen Turingmaschine
@@ -120,7 +120,7 @@ $t_{tm}$ gibt also die jeweilige Worst Case Laufzeit für ein Wort der Länge $n
 Dies erlaubt es uns auch über unendlich große formale Sprachen Aussagen zu treffen,
 indem wir angeben, wie sich der Aufwand bei steigender Inputgröße entwickelt.
 
-\subsection{Untere und Obere Schranken für den Aufwand}
+\subsection{Untere und obere Schranken für den Aufwand}
 Mit $t_{tm}$ und dem Worst Case-Wert können wir Aussagen über den Aufwand treffen,
 den ein bestimmter Algorithmus für ein bestimmtes Problem verursacht.
 Wir treffen allerdings keine Aussagen darüber,
@@ -128,7 +128,7 @@ wie viel Aufwand das Problem \emph{an sich} erzeugt.
 Dazu müssten wir Aussagen über alle prinzipiell \emph{möglichen} Algorithmen,
 also Turingmaschinen treffen,
 die das Problem lösen:
-Den Aufwand eines Problems würden wir dann mit dem effizientestem Algorithmus gleichsetzen.
+Den Aufwand eines Problems würden wir dann mit dem effizientesten Algorithmus gleichsetzen.
 Oftmals ist der Nachweis sehr schwer,
 ob es (k)einen effizienteren Algorithmus
 für ein Problem gibt.
@@ -149,8 +149,8 @@ Algorithmen und Datenstrukturen.
 $t_{tm}$ ist eine Möglichkeit,
 die Aufwandsentwicklung für steigende Inputgrößen formal zu spezfifizieren.
 Für die meisten Fälle ist $t_{tm}$ aber zu feingranular:
-Wir interessieren uns beispielsweise nur,
-ob das Laufzeitverhalten sinnvoll beschränken lässt,
+Wir interessieren uns beispielsweise nur dafür,
+ob sich das Laufzeitverhalten sinnvoll beschränken lässt,
 d.h. ob es eine asymptotische obere oder untere Schranke für den Aufwand gibt.
 
 Dies wird typischerweise mit der Landau-Notation angeben.
@@ -162,7 +162,7 @@ die für die Wachstumsdynamik unwesentlich sind:
 O(g(n)) = \{f|\forall c \exists n_0 \forall n (n \geq n_0 \rightarrow f(n) \leq c \cdot g(n))\}
 \]
 
-TODO: Ergänze andere Klassen (o, $\theta$ usw).
+% TODO: Ergänze andere Klassen (o, $\theta$ usw).
 
 \section{Messen vs. Beweisen}\label{messenVsBeweisen}
 

--- a/content/dfa.tex
+++ b/content/dfa.tex
@@ -109,7 +109,7 @@ und hier ist es sinnvoller mit einem Formalismus zu arbeiten,
 der ``einfacher'' ist als eine typische Programmiersprache.
 Um Programierer:innen bei ihrer Arbeit möglichst effizient zu unterstützen,
 ist eine Programmiersprache typischerweise eher ausdrucksstark.
-Der von von uns gesuchte Formalismus hat aber idealerweise nur wenige, einfache Bestandteile.
+Der von uns gesuchte Formalismus hat aber idealerweise nur wenige, einfache Bestandteile.
 Damit gelingt es uns zum Beispiel schneller Kriterium 5 zu behandeln:
 Wir müssen nur für wenige ``Bauteile'' einer Implementierung zeigen,
 dass sie alle einfach und prinzipiell nutzbar sind.\footnote{
@@ -233,7 +233,7 @@ müssen wir ein paar Hilfskonzepte einführen:
         heißt \emph{Lauf} $l_{w,A}$ für $w$ auf A, wenn gilt:
         \begin{itemize}
             \item Wir haben $w$ als Input und starten beim Anfangszustand:
-                $s_0 = [w,z_i]$ 
+                $s_0 = [w, z_i]$ 
             \item Wir enden, wenn das Wort ``aufgebraucht'' ist:
                 $s_{|w|} = [\epsilon, z]$ mit $z \in Z$,
 
@@ -313,10 +313,10 @@ das praktisch sehr relevant ist.
 Eine nützliche formale Eigenschaft von DFAs ist,
 dass wir sie minimalisieren können.
 Wir können also eine Methode angeben,
-mit der wir aus einem DFA A einen DFA A' ableiten können,
+mit der wir aus einem DFA A einen DFA A$'$ ableiten können,
 dessen Anzahl an Zuständen minimal ist 
 und für den gilt $L(A) = L(A')$,
-das heißt es gibt keinen DFA A'' für den gilt:
+das heißt es gibt keinen DFA A$''$ für den gilt:
 \[|Z''| < |Z'| \wedge L(A'') = L(A') \]
 
 Die grundlegende Idee der Methode besteht darin,
@@ -349,7 +349,7 @@ dass Endzustände und Nicht-Endzustände verschmolzen werden.
 Würden wir diese verschmelzen,
 würde gelten $L(A) \neq L(A')$,
 weil auf einmal ``neue'' Worte akzeptiert werden würden.
-Schritt 4 basiert auf der Annahme, dass zwei Zustände (z, z') verschmolzen werden können,
+Schritt vier basiert auf der Annahme, dass zwei Zustände (z, z') verschmolzen werden können,
 wenn gilt: $\forall a(a \in \Sigma \wedge \delta(a, z) = \delta(a, z'))$,
 also dass man von ihnen die gleichen Zielzustände erreichen kann.
 Die Wiederholung ist nötig,
@@ -458,23 +458,23 @@ wenn wir uns das \emph{Äquivalenzproblem} formaler Sprachen (\textbf{EQUIV})
 vor Augen führen.
 Wir geben dieses Problem informell an ($I_{EQUIV}$):
 \begin{itemize}
-    \item \textbf{Gegeben:} Zwei Automaten A,A'.
-    \item \textbf{Gesucht:} Ein Wahrheitswert, der anzeigt, ob L(A) = L(A').
+    \item \textbf{Gegeben:} Zwei Automaten A, A$'$.
+    \item \textbf{Gesucht:} Ein Wahrheitswert, der anzeigt, ob L(A) = L(A$'$).
 \end{itemize}
 Die Methode zur Minimalisierung gibt uns einen Algorithmus an,
 mit dem wir dieses Problem lösen, also berechnen können.
 Das bedeutet, wir können programmatisch entscheiden,
 indem wir den Minimalautomaten finden:
 \begin{itemize}
-    \item Sind die beiden Probleme L(A) und L(A') identisch?
+    \item Sind die beiden Probleme L(A) und L(A$'$) identisch?
         (Haben sie den selben Minimalautomaten)
-    \item Ist der Algorithmus minimal, den A (bzw. A') kodiert?
+    \item Ist der Algorithmus minimal, den A (bzw. A$'$) kodiert?
 \end{itemize}
 
 Wenn sich nun alle Probleme durch einen DFA charakterisieren ließen,
 also DFA-berechenbar wären,
 hätte die Lösung von \textbf{EQUIV} mächtige Konsequenzen:
-Wir könnten auf einen Schlag die meinsten IT-Fachkräfte überflüssig machen.
+Wir könnten auf einen Schlag die meisten IT-Fachkräfte überflüssig machen.
 Es besteht aber kein Grund zur Sorge, wie wir in \autoref{pumping} sehen werden.
 
 \section{Reguläre Ausdrücke}\label{regex}
@@ -548,7 +548,7 @@ import re
 
 //...
 
-if re.fullmatch("S(0|[1-9]\d*)", supplierid):
+if re.fullmatch("S([1-9][0-9]*)", supplierid):
     // add to database
 else:
     // handle error

--- a/content/dfa.tex
+++ b/content/dfa.tex
@@ -467,7 +467,7 @@ Das bedeutet, wir können programmatisch entscheiden,
 indem wir den Minimalautomaten finden:
 \begin{itemize}
     \item Sind die beiden Probleme L(A) und L(A$'$) identisch?
-        (Haben sie den selben Minimalautomaten)
+        (Haben sie den selben Minimalautomaten?)
     \item Ist der Algorithmus minimal, den A (bzw. A$'$) kodiert?
 \end{itemize}
 

--- a/content/einleitung.tex
+++ b/content/einleitung.tex
@@ -22,10 +22,10 @@ Diese Beispiele für Userstories sollen uns im Skript begleiten:
 \begin{itemize}
 %TODO: Einkommentieren und Bearbeiten, wenn Kapitel geschrieben.
     \item \textbf{U\textsubscript{EVEN}}:
-        >Als Kommisionier:in möchte ich die Anzahl der geplanten Paletten pro LKW kennen,
-         um zu sehen, ob Platz für den Hubwagen bleibt.
+        Als Kommisionier:in möchte ich die Anzahl der geplanten Paletten pro LKW kennen, 
+        um zu sehen, ob Platz für den Hubwagen bleibt.
      \item \textbf{U\textsubscript{SUPPLIERID}}:
-         Als Einkaufsmanager:in möchte ich,
+        Als Einkaufsmanager:in möchte ich,
         dass nur valide Lieferanten-IDs gespeichert werden
         (beginnend mit einem ``S'', gefolgt von einer Zahl),
         um Fehler in der Datenbank zu vermeiden.
@@ -124,7 +124,7 @@ dass die gezeigten Schritte nicht das richtige Resultat für einen anderen Zweck
 Für eine Kommissionierer:in mag die Anzahl noch aus anderen Gründen interessant sein,
 z.B. um die Auslastung der LKWs zu bewerten und zu optimieren.
 Oder es mag nicht gleichgültig sein, ob zwei, drei oder mehr Paletten nebeneinander passen.
-Wie man Abstraktionen im Sinne der Software Entwicklung einsetzen kann,
+Wie man Abstraktionen im Sinne der Softwareentwicklung einsetzen kann,
 lehrt die Disziplin des Software Engineerings.}
 Wir kommen so auf den Kern der Userstory \textbf{U\textsubscript{EVEN}},
 den wir \textbf{I\textsubscript{EVEN}} nennen wollen:

--- a/content/einleitung.tex
+++ b/content/einleitung.tex
@@ -330,7 +330,7 @@ Wie bekommen wir nun ein Problem wie \textbf{I\textsubscript{EVEN}}
 in die Gestalt einer formalen Sprache?
 Für \textbf{EVEN} ist dies recht unkompliziert:
 Wir nutzen $\Sigma = \{0,1\}$ als Alphabet
-und kodieren Zahlen mit Hilfe der folgenden (kanonischen) Binärrepresentation
+und kodieren Zahlen mit Hilfe der folgenden (kanonischen) Binärrepräsentation
 $bin_{\mathbb{N}}: \mathbb{N} \rightarrow \Sigma^*$:
 \[
     bin_{\mathbb{N}}(x) = a_{0}a_{1} \ldots a_{n}
@@ -532,16 +532,16 @@ Repräsentation von Problemen,
 in \autoref{ch:theorie} werden wir Hinweise durchgehen,
 wie man das Studium der formalen Sprachen vertiefen kann.
 
-\section{Kapitelabschluss}
+\section*{Kapitelabschluss}
 \subsection*{Zusammenfassung}
 \begin{itemize}
     \item Erfahrene und kompetente IT-Fachkräfte erfassen den logischen Kern
         von IT-Alltagsaufgaben und können ihre Aufgaben daher effizient erledigen.
     \item Den logischen Kern können wir im gegeben/gesucht-Format fassen
         und so als Funktion verstehen. Diese Auffassung von Problemen nennen wir informell.
-    \item Probleme lassen sich als formale Sprachen repräsentieren.
-    \item Formale Sprachen lassen sich mit den Methoden der theoretischen Informatik
-        bearbeiten.
+    \item Probleme lassen sich (aber auch) als formale Sprachen repräsentieren.
+    \item Vorteil von formalen Sprachen ist, dass sie sich mit den Methoden der theoretischen Informatik
+        bearbeiten lassen.
 \end{itemize}
 \subsection*{Aufgaben}
 \begin{enumerate}

--- a/content/einleitung.tex
+++ b/content/einleitung.tex
@@ -372,7 +372,7 @@ noch einstellig.
 $f_{EVEN}: \mathbb{N} \rightarrow \{0,1\}$ dagegen ist beides.
 
 Für ein Wort $w$, das einen (einfachen) Wert $x$ kodiert,
-gilt $w \in L_{PROBLEM}$, genau dann wenn $f_{PROBLEM}(x) = 1$.
+gilt $w \in L_{PROBLEM}$, genau dann, wenn $f_{PROBLEM}(x) = 1$.
 Dieser Trick funktioniert nicht,
 wenn $x$ komplex ist (d.h. $f_{PROBLEM}$ ist mehrstellig),
 oder der Wertebereich aus mehr als zwei Werten besteht.
@@ -468,7 +468,7 @@ Zudem muss man ein Problem nicht in einer Sprache über einem binären Alphabet
 $\Sigma = \{0,1\}$ kodieren,
 wie wir es im vorangegangenen Abschnitt exemplarisch getan haben.
 Man hätte auch Probleme mit einem unären, ternären
-oder anderen Alphabeten repräsentieren können.\footnote{
+oder anderen Alphabet repräsentieren können.\footnote{
     Interessierte Leser:innen kommen in \cite{knuth2}, Chapter 4 (194-213) auf ihre Kosten.
 }
 Das obige Beispiel ist mit dem binären Alphabet im wahrsten Sinne des Wortes durchbuchstabiert,

--- a/content/grundlagen.tex
+++ b/content/grundlagen.tex
@@ -131,7 +131,7 @@ Die folgenden Äquivalenzen werden in diesem Skript als Schlussregeln genutzt,
 sie lassen sich mit Wahrheitstabellen rechtfertigen:
 \begin{itemize}
     \item Kontraposition:
-        $A \rightarrow B \leftrightarrow \neg B \rightarrow A$
+        $A \rightarrow B \leftrightarrow \neg B \rightarrow \neg A$
     \item DeMorgan (I):
         $\neg (A \wedge B) \leftrightarrow \neg A \vee \neg B$
 
@@ -154,12 +154,12 @@ die interne Struktur von Aussagen zu analysieren.
 Die grundlegende Struktur von Aussagen ist dabei die \emph{Prädikation},
 eben die Aussage, dass 1-n Objekte in einem Verhältnis stehen.
 Zum Beispiel würde die Aussage
-``a ist ein Vokal'' formal mit $V(a)$ wiedergeben,
+``a ist ein Vokal'' formal mit $V(a)$ wiedergegeben,
 wobei $V(x)$ das Prädikat ``x ist ein Vokal'' darstellt
 und ``a'' der Name eines Objekts ist.
 $V(x)$ ist \emph{einstellig},
 Prädikate können aber auch \emph{mehrstellig} sein:
-$ABC(x,y)$ könnte zum Beispiel bedeutet: nach x kommt y im Alphabet.
+$ABC(x,y)$ könnte zum Beispiel bedeuten: nach x kommt y im Alphabet.
 
 Die wesentliche Analysetiefe bekommt die Prädikatenlogik aber dadurch,
 dass sie es erlaubt, mit \emph{Quantoren} Existenz- und Allaussagen zu formalisieren.
@@ -178,7 +178,7 @@ sie hat es ermöglicht, zentrale Ergebnisse der Mathematik präzise zu formulier
 Dies trifft auch auf wichtige Ergebnisse der theoretischen Informatik zu.
 Wir werden in \autoref{pumping} das Pumping-Lemma als ein Beispiel hierfür kennenlernen.
 
-Eine weitere Regel für die Manipulation von Prädikatenlogischen Formeln
+Eine weitere Regel für die Manipulation von prädikatenlogischen Formeln
 sind die Regeln zur \emph{Quantorennegation}:
 \begin{itemize}
     \item $\neg \forall x \phi \leftrightarrow \exists x \neg \phi$
@@ -219,7 +219,7 @@ zum Beispiel ist $\mathbb{N}$ die Menge der natürlichen Zahlen.
 Da es unendlich viele natürlichen Zahlen gibt,
 können wir die Extension nicht angeben
 (alles Papier der Welt wäre nicht genug).
-1,2,3 sind Elemente in beiden Mengen Menge.
+1,2,3 sind Elemente in beiden Mengen.
 Wir schreiben zum Beispiel $1 \in A$ und $1 \in \mathbb{N}$
 um die Elementschaftsbeziehung zwischen Objekt/Element und Menge formal auszudrücken.
 Die leere Menge ist eine spezielle Menge, die keine Elemente enthält,
@@ -239,7 +239,7 @@ Mit dem Begriff \emph{Universum}\footnote{
 } bezeichnen wir die Gesamtheit der Elemente,
 über die wir Aussagen treffen.
 Zum Beispiel wären die natürlichen Zahlen ein Universum.
-Man kann man Mengen auch \emph{intensional} angeben,
+Man kann Mengen auch \emph{intensional} angeben,
 d.h.\ wir geben eine Bedingung an,
 die alle Elemente eines Universums erfüllen müssen.
 Für alle geraden natürlichen Zahlen wäre das z.B.:
@@ -326,7 +326,7 @@ Das Folgende sollten bekannt sein:
     \item Ein Tupel mit n    Elementen heißt n-Tupel.
     \item Das kartesische Produkt zweier Mengen A und B wird mit $A \times B$ bezeichnet
           und ist definiert als: $\{[a,b]|a \in A \wedge b \in B\}$.
-    \item Analog lässts sich das kartesische Produkt von mehr als zwei Mengen definieren.
+    \item Analog lässt sich das kartesische Produkt von mehr als zwei Mengen definieren.
     \item Für einen Tupel $t$ bezeichnet $t_n$ genau das n-te Element des Tupels.
         $n$ heißt Index des Tupels. Die erste Position im Tupel hat den Index 0.
 \end{itemize}
@@ -438,6 +438,6 @@ Ein grundlegendes formales Verständnis von Relationen und Funktionen ist besond
 bei der Frage, wie Maschinen feststellen können,
 ob eine Relation zwischen zwei Objekten besteht
 und noch vielmehr bei der Frage, wie Maschinen Funktionen berechnen können.
-In \autoref{subsec:problemeSprachen} werden wir uns genau diesen Fragen widmen.
+In \autoref{subsec:problemeAlsFormaleSprachen} werden wir uns genau diesen Fragen widmen.
 
 %\subsection{Beweisstrategien \& Beweisskizzen}\label{bew}

--- a/content/preface.tex
+++ b/content/preface.tex
@@ -52,7 +52,7 @@ In \emph{Kapitel 4} zeigen wir,
 wie wir den \emph{Aufwand} quantifizieren können,
 den Berechnungen verursachen. 
 Wir fassen Aufwand genauer als Laufzeit eines Automaten (zeitlicher Aufwand) 
-dessen benötigten (Speicher-)Platz (räumlicher Aufwand).
+oder dessen benötigten (Speicher-)Platz (räumlicher Aufwand).
 Sowohl DFAs als auch Turingmaschinen erlauben es,
 diese Konzepte von Speicherplatz und Laufzeit präzise zu fassen.
 Das Wachstum von Speicherplatz und Laufzeit lässt sich

--- a/content/turing.tex
+++ b/content/turing.tex
@@ -2,7 +2,7 @@
 
 In diesem Kapitel lernen wir ein Problem kennen,
 dass nicht DFA-berechenbar ist,
-d.h. für dessen Formale Sprache kein akzeptierender DFA existiert.
+d.h. für dessen formale Sprache kein akzeptierender DFA existiert.
 Dies beweisen wir mit Hilfe des Pumping-Lemmas,
 das wir informell herleiten.
 Mit den Turingmaschinen lernen wir einen Formalismus kennen,
@@ -244,7 +244,7 @@ Also ist die Sprache nicht regulär und kann nicht von einem DFA erkannt werden.
 \subsection{Grenzen der DFA-Berechenbarkeit}
 $SORTIMENT$ ist ein Problem, das uns \emph{intuitiv} berechenbar erscheint.
 Aber DFAs als Formalismus, um Algorithmen anzugeben,
-ist beweisbar nicht mächtig genug,
+sind beweisbar nicht mächtig genug,
 um $SORTIMENT$ zu berechnen.
 
 Der wesentliche Grund hierfür: ein DFA hat keinen ``Speicher'',
@@ -313,7 +313,7 @@ $TM = [Z, \Sigma, \Gamma, \delta, z_0, \square, E]$:
 \noindent
 Eine Turingmaschine funktioniert intuitiv so:
 \begin{itemize}
-    \item Zusätzlich zum DFA hat sie ein unendliches beschreibbares Band.
+    \item Zusätzlich zum DFA hat sie ein unendliches, beschreibbares Band.
     \item Der Input steht vor dem Lauf auf dem Band.
         Ist ein Input mehrstellig, sind die Wert durch Blanks ($\square$) getrennt.
         Auf allen anderen Position auf dem Band sind Blanks.
@@ -322,9 +322,9 @@ Eine Turingmaschine funktioniert intuitiv so:
         so liest sie das erste Zeichen
         und führt die folgenden drei Dinge wie von $\delta$ angegeben aus:
         \begin{enumerate}
-            \item Das Zeichen wird überschrieben oder bleib identisch.
+            \item Das Zeichen wird überschrieben oder bleibt identisch.
             \item Der Zustand wechselt oder bleibt gleich.
-            \item Der Zeicher bewegt sich nach
+            \item Der Zeiger bewegt sich nach
                 rechts (R),
                 links (L)
                 oder bleibt auf der Position stehen (-).
@@ -572,7 +572,7 @@ ob sie nach endlichen Schritten terminieren.
 Diese Diskussion schieben wir aber bis \autoref{derBarbierUndDerLuegner}.
 Hier halten wir fest: Turingmaschinen repräsentieren in jedem Fall \emph{Berechnungsmethoden}.
 
-Ein letzter Twist bleibt aber für dieses Kapitels:
+Ein letzter Twist bleibt aber für dieses Kapitel:
 Turingmaschinen lassen sich auch als formale Sprache repräsentieren,
 d.h. wir können den 7-Tupel zum Beispiel in eine Binärrepräsentation bringen.
 Diese Tatsache öffnet das Tor zu einer Reihe von möglichen Fragestellungen:
@@ -594,7 +594,7 @@ den Unterschied zwischen Hard- und Software verschwimmen lassen.
 \subsection*{Aufgaben}
 
 \begin{enumerate}
-    \item Gib zwei verschiedene Läufe für Wörter auf der Turingmaschien aus
+    \item Gib zwei verschiedene Läufe für Wörter auf der Turingmaschine aus
         \autoref{fig:tmsortiment} an.
     \item Gegeben sei die folgende Turingmaschine
         $M = \{Z, \{*\}, \{*, \square\}, \delta, z_0, \square, \{z_2\}\}$,
@@ -613,7 +613,7 @@ den Unterschied zwischen Hard- und Software verschwimmen lassen.
         Man kann davon ausgehen, dass der Input (zwei Zahlen in unärer Darstellung)
         mit einem $\square$ getrennt beim Start auf dem Band der Turingmaschine steht.
         In unärer Kodierung gilt: $0 = +, 1 = ++, 2 = +++, \ldots$
-    \item Gegeben sei die Turing Maschine M wie in \autoref{fig:tm34}.
+    \item Gegeben sei die Turingmaschine M wie in \autoref{fig:tm34}.
         \begin{enumerate}
             \item Geben Sie M in der Sprache der Mengenlehre an.
             \item Geben Sie den Lauf von M auf dem Input $||-|$ an.


### PR DESCRIPTION
typo-fixes in preface.tex / einleitung.tex / grundlagen.tex
Kapitelabschluss in einleitung.tex konsistenterweise nicht in tableofcontents
richtiger Verweis bei autoref in grundlagen.tex zu problemeAlsFormaleSprachen