### PR TITLE
quantifzieren zu quantifizieren

### DIFF
--- a/content/acknowledgement.tex
+++ b/content/acknowledgement.tex
@@ -3,5 +3,6 @@ Am Skript haben mitgeholfen
 \begin{itemize}
 \item Tony Klein (WI21A3)
 \item Samis Ellsässer (WI21A3)
+\item Katharina Bäuml (WI22A3)
 \end{itemize}
 Vielen Dank, dass Ihr das Skript besser gemacht habt!

--- a/content/einleitung.tex
+++ b/content/einleitung.tex
@@ -107,7 +107,7 @@ So könnte eine Abstraktion von \textbf{U\textsubscript{EVEN}} für diesen Zweck
          möchte ich die Anzahl der geplanten Paletten pro LKW kennen,
          um zu sehen, ob Platz für den Hubwagen bleibt.
         } (ursprüngliche Userstory).
-    \item \emph{Identifikation der Anzahl an Paletten, um verfügbaren Platz zu quantifzieren.}
+    \item \emph{Identifikation der Anzahl an Paletten, um verfügbaren Platz zu quantifizieren.}
         (die Kenntnis der tatsächlichen Anzahl und wofür der Platz gedacht ist,
         ist für unseren Zweck gleichgültig.)
     \item \emph{Ist die Anzahl an Paletten (un)gerade?}


### PR DESCRIPTION
Ein kleiner Tippfehler wurde korrigiert: 
"quantifzieren" ist nun "quantifizieren" :)